### PR TITLE
[HDRP] Reference pipeline settings

### DIFF
--- a/Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -129,6 +129,15 @@ namespace UnityEngine.Rendering.HighDefinition
         /// </summary>
         public RenderPipelineSettings currentPlatformRenderPipelineSettings { get => m_RenderPipelineSettings ; set { m_RenderPipelineSettings = value; OnValidate(); } }
 
+        // ----------------------NBG----------------------
+        public ref RenderPipelineSettings GetRenderPipelineSettingsReference()
+        {
+            /* This allows us to reference the settings instead of copying the huge amount of data
+               in it when we just want to update some settings */
+            return ref m_RenderPipelineSettings;
+        }
+        // ----------------------NBG----------------------
+        
         internal void TurnOffRayTracing()
         {
             m_RenderPipelineSettings.supportRayTracing = false;

--- a/Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -130,6 +130,11 @@ namespace UnityEngine.Rendering.HighDefinition
         public RenderPipelineSettings currentPlatformRenderPipelineSettings { get => m_RenderPipelineSettings ; set { m_RenderPipelineSettings = value; OnValidate(); } }
 
         // ----------------------NBG----------------------
+        /// <summary>
+        /// Get's a reference to <see cref="RenderPipelineSettings"/> but will not call `OnValidate()`
+        /// To initialise changes, the updated settings need to be assigned to `currentPlatformRenderPipelineSettings`
+        /// </summary>
+        /// <returns></returns>
         public ref RenderPipelineSettings GetRenderPipelineSettingsReference()
         {
             /* This allows us to reference the settings instead of copying the huge amount of data


### PR DESCRIPTION
Adding a public reference to `RenderPipelineSettings` as we update and rebuild the pipeline depending on advanced video settings. So in order to not copy all of the data inside of it, let's just reference it.